### PR TITLE
Fix account helper for ganache-local

### DIFF
--- a/brownie-05-Simple-Storage/scripts/deploy.py
+++ b/brownie-05-Simple-Storage/scripts/deploy.py
@@ -12,11 +12,13 @@ def deploy_simple_storage():
     print(updated_stored_value)
 
 
+LOCAL_BLOCKCHAIN_ENVIRONMENTS = ["development", "ganache-local"]
+
+
 def get_account():
-    if network.show_active() == "development":
+    if network.show_active() in LOCAL_BLOCKCHAIN_ENVIRONMENTS:
         return accounts[0]
-    else:
-        return accounts.add(config["wallets"]["from_key"])
+    return accounts.add(config["wallets"]["from_key"])
 
 
 def main():


### PR DESCRIPTION
## Summary
- use local account when running on `ganache-local`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685736ce407c832498577e1d2f225a06